### PR TITLE
V1.3.3

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -8,7 +8,7 @@
   "realtime_recording": {
     "description": "开启实时监听记录",
     "type": "bool",
-    "hint": "开启后将通过监听 LLM 钩子实时写入聊天记录到 JSON 文件，不再依赖总结时从核心数据库提取。会稍微加大对话时的内存占用。",
+    "hint": "开启后将通过监听 LLM 钩子实时写入聊天记录到 JSON 文件，不再依赖总结时从核心数据库提取。会稍微加大对话时的内存占用。部分平台可能无法正确识别用户名。",
     "default": false
   },
   "memory_db_path": {

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -53,6 +53,12 @@
     "hint": "开启后将强制只读本地模型缓存，彻底避免联网检查（包括 ChromaDB 遥测和 HuggingFace 下载）。请在确认本插件已正常运行过一次且安装的其他插件都不需要连接HuggingFace时再开启。",
     "default": false
   },
+  "model_idle_timeout": {
+    "description": "向量模型自动卸载时长 (分钟)",
+    "type": "int",
+    "hint": "向量模型在闲置多久后自动从内存中释放。-1 表示不自动卸载。建议在内存紧张的环境中设置为 30-60 分钟。",
+    "default": -1
+  },
   "target_user_id_list": {
     "description": "目标会话 ID 列表",
     "type": "list",

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -8,7 +8,7 @@
   "realtime_recording": {
     "description": "开启实时监听记录",
     "type": "bool",
-    "hint": "开启后将通过监听 LLM 钩子实时写入聊天记录到 JSON 文件，不再依赖总结时从核心数据库提取。会稍微加大对话时的内存占用。部分平台可能无法正确识别用户名。",
+    "hint": "开启后将通过监听 LLM 钩子实时写入聊天记录到 JSON 文件，不再依赖总结时从核心数据库提取。会稍微加大对话时的内存占用。",
     "default": false
   },
   "memory_db_path": {
@@ -148,6 +148,25 @@
     "type": "float",
     "hint": "控制匹配到罕见词（TF-IDF权重高）时的加成强度。默认 1.0。",
     "default": 1.0
+  },
+  "dailyreview_nodes": {
+    "description": "每日总结 - 记忆节点配置",
+    "type": "object",
+    "hint": "配置每日总结过程中，如何检索和更新长期记忆节点。",
+    "items": {
+      "include_reflection": {
+        "description": "注入事件反思",
+        "type": "bool",
+        "hint": "开启后，在总结记忆节点时会额外提供事件的reflection（反思）。有助于 AI 记录深层见解和情感波动。",
+        "default": false
+      },
+      "max_reference_nodes": {
+        "description": "参考节点上限",
+        "type": "int",
+        "hint": "当单个关键词唤起多个节点时，最终提供给 AI 的参考节点总数上限。默认 20。",
+        "default": 20
+      }
+    }
   },
   "prompts": {
     "description": "提示词自定义配置",

--- a/chat_history_extract.py
+++ b/chat_history_extract.py
@@ -264,6 +264,8 @@ def clean_dialogue_with_different_limits(
 
             # user 消息
             if role == "user" and final_text:
+                if final_text == "Output your last task result below.":
+                    continue
                 current_username = turn_nickname if turn_nickname else username
                 if len(final_text) <= max_user_chars:
                     daily_txt[date_key].append(f"[{timestamp}] {current_username}: {final_text}")

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import os
+import asyncio
 import json
 import math
 import re
@@ -129,11 +130,25 @@ class LocalReminiscencePlugin(Star):
             hf_endpoint=self.hf_endpoint,
             trust_remote_code=embedding_trust_remote_code,
             offline_mode=self.offline_mode,
-            ai_name=self.ai_name
+            ai_name=self.ai_name,
+            idle_timeout=self.config.get("model_idle_timeout", -1)
         )
+        
+        # 启动背景检测任务
+        asyncio.create_task(self._model_idle_check_loop())
         
         # 延迟初始化固化器，因为需要 LLM 函数
         self.consolidator = None
+
+    async def _model_idle_check_loop(self):
+        """向量模型闲置检测循环"""
+        while True:
+            try:
+                await asyncio.sleep(60) # 每分钟检查一次
+                if hasattr(self, 'vector_db'):
+                    self.vector_db.check_and_unload_model()
+            except Exception as e:
+                logger.error(f"[APLR] 向量模型闲置检测任务异常: {e}")
 
     def _append_to_realtime_log(self, unified_id: str, role: str, content: str):
         """将消息追加到实时日志文件"""

--- a/main.py
+++ b/main.py
@@ -144,7 +144,7 @@ class LocalReminiscencePlugin(Star):
         """向量模型闲置检测循环"""
         while True:
             try:
-                await asyncio.sleep(60) # 每分钟检查一次
+                await asyncio.sleep(600) # 每 10 分钟检查一次
                 if hasattr(self, 'vector_db'):
                     self.vector_db.check_and_unload_model()
             except Exception as e:
@@ -717,8 +717,8 @@ class LocalReminiscencePlugin(Star):
                 
                 # 4. 向量化主题 (现场计算重心)
                 all_themes = self.db.get_all_thematic_memories()
+                themes_to_add = []
                 if all_themes:
-                    themes_to_add = []
                     event_collection = self.vector_db.client.get_collection("events")
                     
                     for t in all_themes:
@@ -731,7 +731,7 @@ class LocalReminiscencePlugin(Star):
                         t_event_ids = [te['event_id'] for te in theme_events]
                         # 从向量库获取 these 事件的向量
                         res = event_collection.get(ids=t_event_ids, include=['embeddings'])
-                        if res['embeddings']:
+                        if res.get('embeddings') and len(res['embeddings']) > 0:
                             # 计算重心
                             embs = np.array(res['embeddings'], dtype=np.float32)
                             centroid = np.mean(embs, axis=0)

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ import subprocess
 import sys
 import numpy as np
 
-@register("local_reminiscence", "olozhika", "基于定时总结和向量化的本地记忆插件", "1.3.2")
+@register("local_reminiscence", "olozhika", "基于定时总结和向量化的本地记忆插件", "1.2.2")
 class LocalReminiscencePlugin(Star):
     def __init__(self, context: Context, config: any = None):
         super().__init__(context)
@@ -583,6 +583,45 @@ class LocalReminiscencePlugin(Star):
             logger.error(f"获取节点背景失败: {e}")
             return [], []
 
+    async def _get_nodes_for_summary(self, text: str, include_username: bool = False) -> list[dict]:
+        """专门为总结/提取环节优化的节点获取逻辑"""
+        
+        # 获取配置
+        dr_nodes_config = self.config.get("dailyreview_nodes", {})
+        max_ref = dr_nodes_config.get("max_reference_nodes", 20)
+        
+        def add_special_nodes(current_nodes):
+            res = list(current_nodes)
+            important_names = []
+            if self.ai_name: important_names.append(self.ai_name)
+            if include_username and self.username: important_names.append(self.username)
+            
+            if important_names:
+                special_nodes = self.db.get_nodes_by_names(important_names)
+                seen_names = {n['name'] for n in res}
+                for sn in special_nodes:
+                    if sn['name'] not in seen_names:
+                        res.append(sn)
+                        seen_names.add(sn['name'])
+            return res
+
+        # 1. 默认检索 1 个 (limit_per_kw=1)
+        nodes1_raw, _ = await self._get_nodes_context(text, include_description=True, max_nodes=100, limit_per_kw=1)
+        nodes1_final = add_special_nodes(nodes1_raw)
+        
+        # 2. 假如去重后记忆节点数目 < 10 个，再试试检索 2 个
+        if len(nodes1_raw) < 10:
+            nodes2_raw, _ = await self._get_nodes_context(text, include_description=True, max_nodes=100, limit_per_kw=2)
+            nodes2_final = add_special_nodes(nodes2_raw)
+            
+            # 3. 最终假如检索数大于 1 (即使用 limit=2)，一定要让最终给的记忆节点数目小于配置上限
+            if len(nodes2_final) < max_ref:
+                return nodes2_final
+            # 否则回退到只检索 1 个的结果
+            return nodes1_final
+        
+        return nodes1_final
+
     @filter.command("daily_summary_command")
     @filter.permission_type(filter.PermissionType.ADMIN)
     async def daily_summary_command(self, event: AstrMessageEvent):
@@ -777,27 +816,25 @@ class LocalReminiscencePlugin(Star):
                 search_events_func=self._search_events_for_summary
             )
 
-            # 获取现有节点背景 (提取节点时也放宽上限，允许描述匹配)
-            nodes_objs, _ = await self._get_nodes_context("\n".join([e['narrative'] for e in events]), include_description=True, max_nodes=100, limit_per_kw=3)
+            # 获取现有节点背景 (提取节点时使用优化的检索逻辑)
+            dr_nodes_config = self.config.get("dailyreview_nodes", {})
+            include_reflection = dr_nodes_config.get("include_reflection", False)
             
-            # 特别确保 ai_name 和 username 也在上下文中（如果存在）
-            important_names = []
-            if self.ai_name: important_names.append(self.ai_name)
-            if self.username: important_names.append(self.username)
+            # 构建用于检索背景的文本。如果开启了反思，则检索背景时也尽量包含它
+            search_text_parts = []
+            for e in events:
+                part = e.get('narrative', '')
+                if include_reflection and e.get('reflection'):
+                    part += f" {e['reflection']}"
+                search_text_parts.append(part)
+                
+            nodes_objs = await self._get_nodes_for_summary("\n".join(search_text_parts), include_username=True)
             
-            if important_names:
-                special_nodes = self.db.get_nodes_by_names(important_names)
-                seen_names = {n['name'] for n in nodes_objs}
-                for sn in special_nodes:
-                    if sn['name'] not in seen_names:
-                        nodes_objs.append(sn)
-                        seen_names.add(sn['name'])
-
             existing_nodes_context = ""
             if nodes_objs:
                 existing_nodes_context = "\n".join([f"- {n['name']}: {n['description']}" for n in nodes_objs])
 
-            nodes_result = await summarizer.extract_nodes_from_events(events, date_str, existing_nodes_context=existing_nodes_context)
+            nodes_result = await summarizer.extract_nodes_from_events(events, date_str, existing_nodes_context=existing_nodes_context, include_reflection=include_reflection)
             if nodes_result:
                 nodes, deleted_nodes = nodes_result
                 if nodes:
@@ -1759,31 +1796,21 @@ class LocalReminiscencePlugin(Star):
                 prompt_memory_node=prompts_config.get("memory_node", "")
             )
 
-            # 获取现有节点背景 (总结时放宽上限，允许描述匹配)
+            # 获取现有节点背景 (总结时使用优化的检索逻辑)
             full_text = "\n".join(conversation_chunks)
-            nodes, _ = await self._get_nodes_context(full_text, include_description=True, max_nodes=100, limit_per_kw=3)
-            
-            # 特别确保 ai_name 也在上下文中（如果存在）
-            important_names = []
-            if self.ai_name: important_names.append(self.ai_name)
-            
-            if important_names:
-                special_nodes = self.db.get_nodes_by_names(important_names)
-                seen_names = {n['name'] for n in nodes}
-                for sn in special_nodes:
-                    if sn['name'] not in seen_names:
-                        nodes.append(sn)
-                        seen_names.add(sn['name'])
+            nodes = await self._get_nodes_for_summary(full_text, include_username=False)
 
             existing_nodes_context = ""
             if nodes:
                 existing_nodes_context = "\n".join([f"- {n['name']}: {n['description']}" for n in nodes])
 
             # 5. 异步调用总结生成
+            dr_nodes_config = self.config.get("dailyreview_nodes", {})
             summary = await summarizer.generate_summary(
                 conversation_chunks, 
                 date_str, 
-                existing_nodes_context=existing_nodes_context
+                existing_nodes_context=existing_nodes_context,
+                include_reflection=dr_nodes_config.get("include_reflection", False)
             )
 
             # --- 记忆固化：增量更新 ---

--- a/main.py
+++ b/main.py
@@ -731,9 +731,10 @@ class LocalReminiscencePlugin(Star):
                         t_event_ids = [te['event_id'] for te in theme_events]
                         # 从向量库获取 these 事件的向量
                         res = event_collection.get(ids=t_event_ids, include=['embeddings'])
-                        if res.get('embeddings') and len(res['embeddings']) > 0:
+                        embeddings = res.get('embeddings')
+                        if embeddings is not None and len(embeddings) > 0:
                             # 计算重心
-                            embs = np.array(res['embeddings'], dtype=np.float32)
+                            embs = np.array(embeddings, dtype=np.float32)
                             centroid = np.mean(embs, axis=0)
                             themes_to_add.append({
                                 "theme_id": theme_id,

--- a/main.py
+++ b/main.py
@@ -823,6 +823,8 @@ class LocalReminiscencePlugin(Star):
             # 注意：即便开启了 include_reflection，也不在检索背景时使用反思内容，以防干扰关键词匹配
             search_text = "\n".join([e.get('narrative', '') for e in events])
             nodes_objs = await self._get_nodes_for_summary(search_text, include_username=False)
+            if nodes_objs:
+                logger.debug(f"[APLR] 提取节点环节提供的参考节点: {[n['name'] for n in nodes_objs]}")
             
             existing_nodes_context = ""
             if nodes_objs:
@@ -1793,6 +1795,8 @@ class LocalReminiscencePlugin(Star):
             # 获取现有节点背景 (总结时使用优化的检索逻辑)
             full_text = "\n".join(conversation_chunks)
             nodes = await self._get_nodes_for_summary(full_text, include_username=False)
+            if nodes:
+                logger.debug(f"[APLR] 每日总结环节提供的参考节点: {[n['name'] for n in nodes]}")
 
             existing_nodes_context = ""
             if nodes:

--- a/main.py
+++ b/main.py
@@ -23,7 +23,7 @@ import subprocess
 import sys
 import numpy as np
 
-@register("local_reminiscence", "olozhika", "基于定时总结和向量化的本地记忆插件", "1.2.2")
+@register("local_reminiscence", "olozhika", "基于定时总结和向量化的本地记忆插件", "1.3.3")
 class LocalReminiscencePlugin(Star):
     def __init__(self, context: Context, config: any = None):
         super().__init__(context)

--- a/main.py
+++ b/main.py
@@ -820,15 +820,9 @@ class LocalReminiscencePlugin(Star):
             dr_nodes_config = self.config.get("dailyreview_nodes", {})
             include_reflection = dr_nodes_config.get("include_reflection", False)
             
-            # 构建用于检索背景的文本。如果开启了反思，则检索背景时也尽量包含它
-            search_text_parts = []
-            for e in events:
-                part = e.get('narrative', '')
-                if include_reflection and e.get('reflection'):
-                    part += f" {e['reflection']}"
-                search_text_parts.append(part)
-                
-            nodes_objs = await self._get_nodes_for_summary("\n".join(search_text_parts), include_username=True)
+            # 注意：即便开启了 include_reflection，也不在检索背景时使用反思内容，以防干扰关键词匹配
+            search_text = "\n".join([e.get('narrative', '') for e in events])
+            nodes_objs = await self._get_nodes_for_summary(search_text, include_username=False)
             
             existing_nodes_context = ""
             if nodes_objs:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 name: astrbot_plugin_local_reminiscence # 插件唯一识别名，以 astrbot_plugin_ 前缀开头
 display_name: 本地回忆[APLR] # 用于展示的名字，可以是方便人类阅读的名字（需要版本 >= v4.5.0，低版本不会报错，请放心填写）
 desc: 轻量级本地记忆插件，使用本地Embedding模型、本地数据库存储和回忆聊天记录。无需额外API，零Embedding成本，节约Token，完全保护隐私。使用Cron Job自动记录对话，通过关键词和语义匹配帮助AI自动回忆起相关经历和概念。支持多会话和群聊，提供境内网络友好的依赖与模型下载配置。跨对话、跨平台长期记忆！ 
-version: v1.3.2 # 插件版本号。格式：v1.1.1 或者 v1.1
+version: v1.3.3 # 插件版本号。格式：v1.1.1 或者 v1.1
 author: olozhika # 作者
 repo: https://github.com/olozhika/astrbot_plugin_local_reminiscence # 插件的仓库地址

--- a/summarizer.py
+++ b/summarizer.py
@@ -52,12 +52,15 @@ class DailySummarizer:
         
         return s
 
-    async def extract_nodes_from_events(self, events: List[dict], date_str: str, existing_nodes_context: str = "") -> tuple[list, list] | None:
+    async def extract_nodes_from_events(self, events: List[dict], date_str: str, existing_nodes_context: str = "", include_reflection: bool = False) -> tuple[list, list] | None:
         """从已有的事件叙述中提取记忆节点"""
         if not events:
             return [], []
             
-        events_text = "\n---\n".join([f"事件ID: {ev['event_id']}\n叙述: {ev['narrative']}" for ev in events])
+        if include_reflection:
+            events_text = "\n---\n".join([f"事件ID: {ev['event_id']}\n叙述: {ev['narrative']}\n反思: {ev.get('reflection', '无')}" for ev in events])
+        else:
+            events_text = "\n---\n".join([f"事件ID: {ev['event_id']}\n叙述: {ev['narrative']}" for ev in events])
         
         from .models import MemoryNode
         schema_dict = {
@@ -103,7 +106,7 @@ class DailySummarizer:
             logger.error(f"提取节点时发生错误: {e}", exc_info=True)
             return None
 
-    async def generate_summary(self, conversation_chunks: List[str], date_str: str, existing_nodes_context: str = "") -> DailySummary | None:
+    async def generate_summary(self, conversation_chunks: List[str], date_str: str, existing_nodes_context: str = "", include_reflection: bool = False) -> DailySummary | None:
         """两阶段总结法：
         1. 提取今日事件与日感想（支持分段处理）。
         2. 提取/更新记忆节点。
@@ -208,7 +211,7 @@ class DailySummarizer:
             if summary.events:
                 logger.info(f"[APLR] 执行第二阶段总结：提取记忆节点...")
                 events_list = [e if isinstance(e, dict) else e.model_dump() for e in summary.events]
-                nodes_result = await self.extract_nodes_from_events(events_list, date_str, existing_nodes_context=existing_nodes_context)
+                nodes_result = await self.extract_nodes_from_events(events_list, date_str, existing_nodes_context=existing_nodes_context, include_reflection=include_reflection)
                 if nodes_result:
                     summary.nodes, summary.deleted_nodes = nodes_result
 

--- a/vector_db.py
+++ b/vector_db.py
@@ -1,5 +1,7 @@
 import os
 import re
+import time
+import gc
 from pathlib import Path
 from typing import List, Dict, Optional
 from astrbot.api import logger
@@ -13,11 +15,14 @@ class VectorDB:
         hf_endpoint: str = "",
         trust_remote_code: bool = False,
         offline_mode: bool = False,
-        ai_name: str = ""
+        ai_name: str = "",
+        idle_timeout: int = -1
     ):
         self.db_path = db_path
         self.offline_mode = offline_mode
         self.ai_name = ai_name
+        self.idle_timeout = idle_timeout
+        self.last_access_time = time.time()
         
         if self.offline_mode:
             os.environ["TRANSFORMERS_OFFLINE"] = "1"
@@ -218,7 +223,9 @@ class VectorDB:
             raise RuntimeError("\n".join(tips)) from exc
 
     def _ensure_model(self):
+        self.last_access_time = time.time()
         if self.model is None:
+            logger.info("[APLR] 正在加载向量模型...")
             self.model = self._load_embedding_model(
                 model_name=self.model_name,
                 model_cache_dir=self.model_cache_dir,
@@ -226,6 +233,22 @@ class VectorDB:
                 trust_remote_code=self.trust_remote_code,
                 offline_mode=self.offline_mode
             )
+
+    def check_and_unload_model(self):
+        """检查并根据闲置时间卸载模型"""
+        if self.idle_timeout > 0 and self.model is not None:
+            if time.time() - self.last_access_time > self.idle_timeout * 60:
+                logger.info(f"[APLR] 向量模型已闲置超过 {self.idle_timeout} 分钟，正在从内存释放...")
+                self.model = None
+                gc.collect()
+                try:
+                    import torch
+                    if torch.cuda.is_available():
+                        torch.cuda.empty_cache()
+                except:
+                    pass
+                return True
+        return False
 
     def get_embeddings(self, texts: List[str]) -> List[List[float]]:
         """获取文本的向量表示（供外部插件调用）"""


### PR DESCRIPTION
1. 在设置中增加每日总结-记忆节点环节配置
  - 可选是否额外为LLM提供它所总结的事件反思（详细心得）
  - 可以自行设置此环节"每关键词唤起多个节点时"为LLM最多提供的节点数，有效防止LLM注意力分散
2. 在设置中增加配置，支持向量模型闲置一段时间后自动取消挂载
3. 修复了使用vectorize指令重新向量化所有事件和主题时，主题记忆向量写入报错的bug