### PR TITLE
fix: pass plugin name to StarTools.get_data_dir() to avoid inspect.stack() crash

### DIFF
--- a/main.py
+++ b/main.py
@@ -91,7 +91,7 @@ class LocalReminiscencePlugin(Star):
         memory_db_path_rel = self.config.get("memory_db_path", "APLR_DailyReview.db")
         vector_db_path_rel = self.config.get("vector_db_path", "APLR_VectorDB")
 
-        data_dir = StarTools.get_data_dir()
+        data_dir = StarTools.get_data_dir("astrbot_plugin_local_reminiscence")
         
         # 路径解析逻辑：优先考虑绝对路径，否则相对于插件数据目录
         def resolve_path(path_str, data_path):


### PR DESCRIPTION
### Problem
When `StarTools.get_data_dir()` is called without arguments, the framework attempts to deduce the calling plugin name using `inspect.stack()`. Under certain environments (such as dynamic reloading, testing shims, or direct scripts where `__main__` is the entrypoint), metadata extraction fails, throwing a fatal `RuntimeError: 无法获取模块 __main__ 的元信息`.

### Solution
Explicitly pass the plugin name `"astrbot_plugin_local_reminiscence"` to the call of `StarTools.get_data_dir()` in `main.py` to avoid this dynamic inspection crash. This is safe, backwards-compatible, and robust across all execution environments.

### Validation
- Verified and tested successfully under AstrBot official environment.

---

### 💡 Ecosystem & Framework Context
This issue stems from a known vulnerability in the AstrBot core framework's path-resolving API. We have submitted a root-cause fix to the official AstrBot core repository: **[AstrBot Core PR #8588](https://github.com/AstrBotDevs/AstrBot/pull/8588)**.

However, this plugin-level change (passing the plugin name explicitly) remains **highly necessary** to ensure backward compatibility. It prevents the plugin from crashing on older installations of AstrBot that have not upgraded to the latest core version.

This is a safe, non-breaking, and recommended change.